### PR TITLE
fix: drop sway-session.target, now shipped by sway >=1.12

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ _pkgname=sway-services
 pkgname=${_pkgname}
 pkgdesc="Collection of sway and friends systemd unit files"
 pkgver=r33.e3d9b8b
-pkgrel=3
+pkgrel=4
 arch=(any)
 depends=('sway' 'python3' 'python-yaml' 'swayidle')
 makedepends=('meson')
@@ -34,5 +34,10 @@ build() {
 
 package() {
 	DESTDIR="${pkgdir}" ninja -C "${srcdir}/build" install
+	# sway >=1.12 ships its own /usr/lib/systemd/user/sway-session.target,
+	# which collides with the copy from upstream sway-services. Drop ours and
+	# let the sway package own it; sway-session-pre.target (which sway does not
+	# provide) and the wayland-session targets are still installed from here.
+	rm -f "${pkgdir}/usr/lib/systemd/user/sway-session.target"
 	install -D -m 0644 "${srcdir}/${_pkgname}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }


### PR DESCRIPTION
## Problem

`sway` `1:1.12-3` started shipping its own systemd integration:

- `/usr/lib/systemd/user/sway-session.target`
- `/etc/sway/config.d/50-systemd-user.conf`

That target collides with the identically-pathed unit `sway-services` installs (upstream `systemd/meson.build` → `install_data([…, 'sway-session.target', …], install_dir: 'lib/systemd/user')`). Any pacman transaction pulling in both packages now fails:

```
error: failed to commit transaction (conflicting files)
/usr/lib/systemd/user/sway-session.target exists in both 'sway' and 'sway-services'
```

This is what broke the `manjaro-sway-settings` unstable build (deps `sway` + `sway-services` can no longer be co-installed): https://github.com/manjaro-sway/manjaro-sway-settings/actions/runs/27940020213/job/82670884068

## Fix

Remove our copy of `sway-session.target` in `package()` and let the `sway` package own it. Bump `pkgrel` 3 → 4 so the rebuild actually ships (pkgver stays pinned to upstream commit `e3d9b8b`).

## Why this is safe

- `sway` only ships `sway-session.target`, **not** `sway-session-pre.target` — `sway-services` still installs that (and the `wayland-session{,-pre}.target` units), so the manjaro-sway service wiring keeps resolving by name.
- The `manjaro-sway-settings` units reference only `sway-session.target` / `sway-session-pre.target` (`PartOf=`/`WantedBy=`/`After=`/`BindsTo=`), never `wayland-session.target`, so dropping our copy doesn't unwire anything.

### Semantic note (for reviewer)

The two `sway-session.target` files differ slightly:

- ours: `BindsTo=wayland-session.target`
- sway's: `BindsTo=graphical-session.target`

So the `wayland-session.target` intermediary is no longer wired to `sway-session.target`. Unused by manjaro-sway today, but worth a glance if anything relies on the wayland-session layer. sway's new `config.d/50-systemd-user.conf` also auto-starts `sway-session.target` itself — confirm that doesn't double up with the existing session-start path.